### PR TITLE
feat: support autoplay on production overlay without debug UI

### DIFF
--- a/app/components/Debug.vue
+++ b/app/components/Debug.vue
@@ -90,7 +90,8 @@ onChange(async () => {
   r.onload = () => {
     try {
       const data = JSON.parse(r.result as string)
-      const eventName: string = nameFromPath(f.name).split('.')[0] ?? nameFromPath(f.name)
+      const baseName = nameFromPath(f.name)
+      const eventName: string = baseName.split('.')[0] || baseName
       const e = new MessageEvent(
         eventName,
         { data: JSON.stringify(data) }

--- a/app/components/Debug.vue
+++ b/app/components/Debug.vue
@@ -69,11 +69,13 @@
 </template>
 
 <script setup lang="ts">
-import { onUnmounted } from 'vue'
-import { useLocalStorage, useFileDialog } from '@vueuse/core'
+import { useFileDialog } from '@vueuse/core'
 
 import GfxMain from './gfx/Main.vue'
 import { eventSource } from '~/state'
+import { useAutoplay } from '~/composables/useAutoplay'
+
+const { autoplay, demoKeys, fire, hide, nameFromPath } = useAutoplay()
 
 const { files, open: openFileModal, onChange } = useFileDialog({
   accept: '.json',
@@ -88,7 +90,7 @@ onChange(async () => {
   r.onload = () => {
     try {
       const data = JSON.parse(r.result as string)
-      const eventName: string = nameFromPath(f.name).split('.')[0]
+      const eventName: string = nameFromPath(f.name).split('.')[0] ?? nameFromPath(f.name)
       const e = new MessageEvent(
         eventName,
         { data: JSON.stringify(data) }
@@ -100,81 +102,5 @@ onChange(async () => {
     }
   }
   r.readAsText(f)
-})
-
-const params = new URLSearchParams(window.location.search)
-// const isDebug = params.has('debug')
-const autoplay = params.has('autoplay')
-const show = params.get('show')
-
-const demos: Record<string, any> = import.meta.glob('./demo/*.json', {
-  eager: true
-})
-
-const demoKeys = Object.keys(demos)
-
-const nameFromPath = (path: string) => {
-  // get the filename from the path
-  const parts = path.split('/')
-  const filename = parts[parts.length - 1]
-  // remove the file extension (anything after the last dot)
-  return filename.split('.').slice(0, -1).join('.')
-}
-
-const hide = () => {
-  eventSource.value?.dispatchEvent(new MessageEvent('hide'))
-}
-
-const fire = (f: string) => {
-  // first part before dot is the event name
-  const eventName = nameFromPath(f).split('.')[0]
-  const payload = demos[f].default
-
-  const e = new MessageEvent(
-    eventName,
-    { data: JSON.stringify(payload) }
-  )
-  eventSource.value?.dispatchEvent(e)
-}
-
-// TODO: receive event stream and send demo data
-
-const showDuration = 1500
-const hideDuration = 200
-
-let id: number | undefined = undefined
-const i = useLocalStorage('autoPlayIndex', 0)
-
-if (autoplay) {
-  const demoKeysRandom = [...demoKeys].sort(() => Math.random() - 0.5)
-
-  const loop = () => {
-    if (i.value >= demoKeys.length) {
-      i.value = 0
-    }
-    const f = demoKeysRandom[i.value]
-    fire(f)
-    i.value++
-
-    window.setTimeout(() => {
-      hide()
-    }, showDuration)
-  }
-  loop()
-  id = window.setInterval(loop, showDuration + hideDuration)
-} else if (show) {
-  const f = demoKeys.find(d => d.includes(show))
-  if (f) {
-    hide()
-    fire(f)
-  } else {
-    console.warn(`No demo found for show: ${show}`)
-  }
-}
-
-onUnmounted(() => {
-  if (autoplay && id) {
-    window.clearInterval(id)
-  }
 })
 </script>

--- a/app/composables/useAutoplay.ts
+++ b/app/composables/useAutoplay.ts
@@ -1,13 +1,9 @@
-import { onUnmounted } from 'vue'
+import { onUnmounted, ref } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 
 import { eventSource, params } from '~/state'
 
-const demos: Record<string, any> = import.meta.glob('../components/demo/*.json', {
-  eager: true,
-})
-
-const demoKeys = Object.keys(demos)
+const demoModules = import.meta.glob('../components/demo/*.json')
 
 const nameFromPath = (path: string) => {
   const filename = path.split('/').pop() ?? path
@@ -18,13 +14,22 @@ const hide = () => {
   eventSource.value?.dispatchEvent(new MessageEvent('hide'))
 }
 
-const fire = (f: string) => {
-  const eventName = nameFromPath(f).split('.')[0] ?? nameFromPath(f)
-  const payload = demos[f].default
+const loadDemo = async (path: string) => {
+  const loader = demoModules[path]
+  if (!loader) return undefined
+  const mod = await loader() as { default: unknown }
+  return mod.default
+}
+
+const fire = async (path: string) => {
+  const name = nameFromPath(path)
+  const eventName = name.split('.')[0] || name
+  const payload = await loadDemo(path)
+  if (!payload) return
 
   const e = new MessageEvent(
     eventName,
-    { data: JSON.stringify(payload) },
+    { data: JSON.stringify(payload) }
   )
   eventSource.value?.dispatchEvent(e)
 }
@@ -35,44 +40,57 @@ const HIDE_DURATION = 200
 export function useAutoplay() {
   const autoplay = params.has('autoplay')
   const show = params.get('show')
+  const demoKeys = ref<string[]>([])
 
   let intervalId: number | undefined
+  let timeoutIds: number[] = []
   const autoPlayIndex = useLocalStorage('autoPlayIndex', 0)
 
-  if (autoplay) {
-    const demoKeysRandom = [...demoKeys].sort(() => Math.random() - 0.5)
+  const init = async () => {
+    demoKeys.value = Object.keys(demoModules)
 
-    const loop = () => {
-      if (autoPlayIndex.value >= demoKeys.length) {
-        autoPlayIndex.value = 0
+    if (autoplay) {
+      const demoKeysRandom = [...demoKeys.value].sort(() => Math.random() - 0.5)
+
+      const loop = async () => {
+        if (autoPlayIndex.value >= demoKeys.value.length) {
+          autoPlayIndex.value = 0
+        }
+        const f = demoKeysRandom[autoPlayIndex.value]
+        if (!f) return
+        await fire(f)
+        autoPlayIndex.value++
+
+        const tid = window.setTimeout(() => {
+          hide()
+        }, SHOW_DURATION)
+        timeoutIds.push(tid)
       }
-      const f = demoKeysRandom[autoPlayIndex.value]
-      if (!f) return
-      fire(f)
-      autoPlayIndex.value++
-
-      window.setTimeout(() => {
+      await loop()
+      intervalId = window.setInterval(loop, SHOW_DURATION + HIDE_DURATION)
+    }
+    else if (show) {
+      const f = demoKeys.value.find(d => d.includes(show))
+      if (f) {
         hide()
-      }, SHOW_DURATION)
-    }
-    loop()
-    intervalId = window.setInterval(loop, SHOW_DURATION + HIDE_DURATION)
-  }
-  else if (show) {
-    const f = demoKeys.find(d => d.includes(show))
-    if (f) {
-      hide()
-      fire(f)
-    }
-    else {
-      console.warn(`No demo found for show: ${show}`)
+        await fire(f)
+      }
+      else {
+        console.warn(`No demo found for show: ${show}`)
+      }
     }
   }
+
+  init()
 
   onUnmounted(() => {
     if (intervalId) {
       window.clearInterval(intervalId)
     }
+    for (const tid of timeoutIds) {
+      window.clearTimeout(tid)
+    }
+    timeoutIds = []
   })
 
   return {
@@ -80,6 +98,6 @@ export function useAutoplay() {
     demoKeys,
     fire,
     hide,
-    nameFromPath,
+    nameFromPath
   }
 }

--- a/app/composables/useAutoplay.ts
+++ b/app/composables/useAutoplay.ts
@@ -1,4 +1,4 @@
-import { onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 
 import { eventSource, params } from '~/state'
@@ -42,8 +42,9 @@ export function useAutoplay() {
   const show = params.get('show')
   const demoKeys = ref<string[]>([])
 
-  let intervalId: number | undefined
-  let timeoutIds: number[] = []
+  let loopTimeoutId: number | undefined
+  let hideTimeoutId: number | undefined
+  let stopped = false
   const autoPlayIndex = useLocalStorage('autoPlayIndex', 0)
 
   const init = async () => {
@@ -53,6 +54,7 @@ export function useAutoplay() {
       const demoKeysRandom = [...demoKeys.value].sort(() => Math.random() - 0.5)
 
       const loop = async () => {
+        if (stopped) return
         if (autoPlayIndex.value >= demoKeys.value.length) {
           autoPlayIndex.value = 0
         }
@@ -61,13 +63,13 @@ export function useAutoplay() {
         await fire(f)
         autoPlayIndex.value++
 
-        const tid = window.setTimeout(() => {
+        hideTimeoutId = window.setTimeout(() => {
           hide()
         }, SHOW_DURATION)
-        timeoutIds.push(tid)
+
+        loopTimeoutId = window.setTimeout(loop, SHOW_DURATION + HIDE_DURATION)
       }
       await loop()
-      intervalId = window.setInterval(loop, SHOW_DURATION + HIDE_DURATION)
     }
     else if (show) {
       const f = demoKeys.value.find(d => d.includes(show))
@@ -81,16 +83,20 @@ export function useAutoplay() {
     }
   }
 
-  init()
+  onMounted(() => {
+    void init().catch((error) => {
+      console.error('Failed to initialize autoplay', error)
+    })
+  })
 
   onUnmounted(() => {
-    if (intervalId) {
-      window.clearInterval(intervalId)
+    stopped = true
+    if (loopTimeoutId) {
+      window.clearTimeout(loopTimeoutId)
     }
-    for (const tid of timeoutIds) {
-      window.clearTimeout(tid)
+    if (hideTimeoutId) {
+      window.clearTimeout(hideTimeoutId)
     }
-    timeoutIds = []
   })
 
   return {

--- a/app/composables/useAutoplay.ts
+++ b/app/composables/useAutoplay.ts
@@ -1,0 +1,85 @@
+import { onUnmounted } from 'vue'
+import { useLocalStorage } from '@vueuse/core'
+
+import { eventSource, params } from '~/state'
+
+const demos: Record<string, any> = import.meta.glob('../components/demo/*.json', {
+  eager: true,
+})
+
+const demoKeys = Object.keys(demos)
+
+const nameFromPath = (path: string) => {
+  const filename = path.split('/').pop() ?? path
+  return filename.split('.').slice(0, -1).join('.')
+}
+
+const hide = () => {
+  eventSource.value?.dispatchEvent(new MessageEvent('hide'))
+}
+
+const fire = (f: string) => {
+  const eventName = nameFromPath(f).split('.')[0] ?? nameFromPath(f)
+  const payload = demos[f].default
+
+  const e = new MessageEvent(
+    eventName,
+    { data: JSON.stringify(payload) },
+  )
+  eventSource.value?.dispatchEvent(e)
+}
+
+const SHOW_DURATION = 1500
+const HIDE_DURATION = 200
+
+export function useAutoplay() {
+  const autoplay = params.has('autoplay')
+  const show = params.get('show')
+
+  let intervalId: number | undefined
+  const autoPlayIndex = useLocalStorage('autoPlayIndex', 0)
+
+  if (autoplay) {
+    const demoKeysRandom = [...demoKeys].sort(() => Math.random() - 0.5)
+
+    const loop = () => {
+      if (autoPlayIndex.value >= demoKeys.length) {
+        autoPlayIndex.value = 0
+      }
+      const f = demoKeysRandom[autoPlayIndex.value]
+      if (!f) return
+      fire(f)
+      autoPlayIndex.value++
+
+      window.setTimeout(() => {
+        hide()
+      }, SHOW_DURATION)
+    }
+    loop()
+    intervalId = window.setInterval(loop, SHOW_DURATION + HIDE_DURATION)
+  }
+  else if (show) {
+    const f = demoKeys.find(d => d.includes(show))
+    if (f) {
+      hide()
+      fire(f)
+    }
+    else {
+      console.warn(`No demo found for show: ${show}`)
+    }
+  }
+
+  onUnmounted(() => {
+    if (intervalId) {
+      window.clearInterval(intervalId)
+    }
+  })
+
+  return {
+    autoplay,
+    demoKeys,
+    fire,
+    hide,
+    nameFromPath,
+  }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,3 +1,9 @@
 <template>
   <GfxMain />
 </template>
+
+<script setup lang="ts">
+import { useAutoplay } from '~/composables/useAutoplay'
+
+useAutoplay()
+</script>


### PR DESCRIPTION
## Summary

- Extract autoplay/show/demo logic from `Debug.vue` into `useAutoplay()` composable
- Use the composable in `index.vue` so `/?autoplay` cycles demo scenes on the clean production overlay (no debug checkerboard, no controls)
- `/debug?autoplay` continues to work as before with debug styling