### PR TITLE
feat(control): add honor-system operator lock via SSE proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "embed"
+	"encoding/json"
 	libsse "github.com/alexandrevicenzi/go-sse"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
@@ -11,8 +12,19 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 )
 import "github.com/gin-contrib/cors"
+
+type controlLock struct {
+	mu       sync.Mutex
+	Holder   string    `json:"holder"`
+	Since    time.Time `json:"since"`
+	Acquired bool      `json:"acquired"`
+}
+
+var lock controlLock
 
 func main() {
 	r := gin.New()
@@ -42,6 +54,59 @@ func main() {
 	})
 	r.GET("/", func(c *gin.Context) {
 		c.String(http.StatusOK, "OK")
+	})
+
+	broadcastLock := func() {
+		lock.mu.Lock()
+		payload, _ := json.Marshal(map[string]any{
+			"holder":   lock.Holder,
+			"since":    lock.Since,
+			"acquired": lock.Acquired,
+		})
+		lock.mu.Unlock()
+		sse.SendMessage(defaultChannel, libsse.NewMessage("", string(payload), "control-lock"))
+	}
+
+	r.GET("/control/status", func(c *gin.Context) {
+		lock.mu.Lock()
+		defer lock.mu.Unlock()
+		c.JSON(http.StatusOK, gin.H{
+			"holder":   lock.Holder,
+			"since":    lock.Since,
+			"acquired": lock.Acquired,
+		})
+	})
+
+	r.POST("/control/acquire", func(c *gin.Context) {
+		var body struct {
+			Holder string `json:"holder"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil || body.Holder == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "holder name is required"})
+			return
+		}
+
+		lock.mu.Lock()
+		lock.Holder = body.Holder
+		lock.Since = time.Now()
+		lock.Acquired = true
+		lock.mu.Unlock()
+
+		slog.InfoContext(c, "control acquired", "holder", body.Holder)
+		broadcastLock()
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	r.POST("/control/release", func(c *gin.Context) {
+		lock.mu.Lock()
+		lock.Holder = ""
+		lock.Since = time.Time{}
+		lock.Acquired = false
+		lock.mu.Unlock()
+
+		slog.InfoContext(c, "control released")
+		broadcastLock()
+		c.JSON(http.StatusOK, gin.H{"ok": true})
 	})
 
 	r.NoRoute(func(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -58,12 +58,14 @@ func main() {
 
 	broadcastLock := func() {
 		lock.mu.Lock()
-		payload, _ := json.Marshal(map[string]any{
-			"holder":   lock.Holder,
-			"since":    lock.Since,
-			"acquired": lock.Acquired,
-		})
+		snapshot := struct {
+			Holder   string    `json:"holder"`
+			Since    time.Time `json:"since"`
+			Acquired bool      `json:"acquired"`
+		}{lock.Holder, lock.Since, lock.Acquired}
 		lock.mu.Unlock()
+
+		payload, _ := json.Marshal(snapshot)
 		sse.SendMessage(defaultChannel, libsse.NewMessage("", string(payload), "control-lock"))
 	}
 
@@ -81,7 +83,11 @@ func main() {
 		var body struct {
 			Holder string `json:"holder"`
 		}
-		if err := c.ShouldBindJSON(&body); err != nil || body.Holder == "" {
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON", "details": err.Error()})
+			return
+		}
+		if body.Holder == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "holder name is required"})
 			return
 		}


### PR DESCRIPTION
## Summary

- Add in-memory control lock state with mutex-protected holder/since/acquired fields
- Add `GET /control/status`, `POST /control/acquire`, `POST /control/release` endpoints
- Broadcast `control-lock` SSE event on every state change for real-time UI sync

Honor-system lock — always overridable, prevents accidental concurrent graphics control.

Companion UI: cmelakmartin/orienteering-tv-graphics#feat/control-lock