### PR TITLE
feat(iof): international display for IOF preview screenshots

### DIFF
--- a/app/components/gfx/ResultsTable.vue
+++ b/app/components/gfx/ResultsTable.vue
@@ -2,10 +2,10 @@
   <div class="Table rounded-[var(--gfx-radius)] overflow-hidden">
     <div class="Table__Title Table__Title--highlight Animate__Slide">
       <span
+        v-if="!isIOF"
         class="Gfx__Control Gfx__Control--invert"
         :class="{ 'Gfx__Control--finish': data.finish }"
       ><span /></span>
-      <img v-if="isIOF" src="/img/iof-logo.png" alt="IOF" class="h-10 w-auto" />
       <span
         class="mr-auto"
         v-text="data.label"

--- a/app/components/gfx/StartList.vue
+++ b/app/components/gfx/StartList.vue
@@ -2,7 +2,6 @@
   <div class="Table rounded-[var(--gfx-radius)] overflow-hidden">
     <div class="Table__Title Animate__Slide">
       <co-symbol v-if="!isIOF" class="fill-gfx-primary h-[var(--text-lg--line-height)]" />
-      <img v-if="isIOF" src="/img/iof-logo.png" alt="IOF" class="h-10 w-auto" />
       <span
         class="mr-auto"
         v-text="data.label"

--- a/app/composables/useAutoplay.ts
+++ b/app/composables/useAutoplay.ts
@@ -21,11 +21,26 @@ const loadDemo = async (path: string) => {
   return mod.default
 }
 
+const isIOF = params.get('theme') === 'iof'
+
+const applyInternationalMode = (payload: unknown): unknown => {
+  if (typeof payload !== 'object' || payload === null) return payload
+  const data = payload as Record<string, unknown>
+  if ('is_national' in data) {
+    return { ...data, is_national: false }
+  }
+  return data
+}
+
 const fire = async (path: string) => {
   const name = nameFromPath(path)
   const eventName = name.split('.')[0] || name
-  const payload = await loadDemo(path)
+  let payload = await loadDemo(path)
   if (!payload) return
+
+  if (isIOF) {
+    payload = applyInternationalMode(payload)
+  }
 
   const e = new MessageEvent(
     eventName,

--- a/app/types/format-duration-time.d.ts
+++ b/app/types/format-duration-time.d.ts
@@ -1,0 +1,7 @@
+declare module 'format-duration-time' {
+  interface Duration {
+    format(pattern: string): string
+  }
+
+  export default function duration(value: number, unit?: string): Duration
+}


### PR DESCRIPTION
## Summary
- Override `is_national` to `false` in demo data when IOF theme is active, so MR preview screenshots show country flags instead of club names
- Add missing type declaration for `format-duration-time` module