### PR TITLE
feat(gfx): add PS results overlay triggered via SSE

### DIFF
--- a/app/components/gfx/Main.vue
+++ b/app/components/gfx/Main.vue
@@ -26,6 +26,7 @@ import { IconSpeakerphone } from '@tabler/icons-vue'
 import Flowers from './Flowers.vue'
 import LiveFeed from './LiveFeed.vue'
 import ResultsTable from './ResultsTable.vue'
+import PsResultsOverlay from './PsResultsOverlay.vue'
 
 import { eventSource } from '~/state'
 import { useTheme } from '~/composables/useTheme'
@@ -114,6 +115,16 @@ watchEffect((onCleanup) => {
       <ResultsTable
         v-if="state.results !== null"
         :data="state.results"
+        class="absolute top-36 left-120 right-120"
+      />
+    </Transition>
+    <Transition
+      name="nested-slide"
+      :duration="500"
+    >
+      <PsResultsOverlay
+        v-if="state.psResults !== null"
+        :trigger="state.psResults"
         class="absolute top-36 left-120 right-120"
       />
     </Transition>

--- a/app/components/gfx/PsResultsOverlay.vue
+++ b/app/components/gfx/PsResultsOverlay.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import type { IPsResultsTrigger } from '~/types/api.d'
+import type { IResults } from '~/types/api.d'
+import { fetchOResults } from '~/utils/psResults'
+import { computeGroupStandings, DEFAULT_CATEGORY_GROUPS } from '~/utils/psResults'
+import ResultsTable from './ResultsTable.vue'
+
+const props = defineProps<{
+  trigger: IPsResultsTrigger
+}>()
+
+const results = ref<IResults | null>(null)
+
+onMounted(async () => {
+  try {
+    const response = await fetchOResults(props.trigger.eventId, 0)
+    const group = DEFAULT_CATEGORY_GROUPS.find(g => g.name === props.trigger.group)
+    if (!group) {
+      console.error(`Unknown PS results group: ${props.trigger.group}`)
+      return
+    }
+
+    const standings = computeGroupStandings(response.runners, group, 2)
+
+    results.value = {
+      label: props.trigger.final ? 'Konečné výsledky' : 'Průběžné výsledky',
+      class: group.name,
+      page: 1,
+      finish: props.trigger.final,
+      is_national: true,
+      is_relay: false,
+      data: standings.standings.map((team, idx) => ({
+        position: String(idx + 1),
+        name: team.team,
+        nationality: 'CZE',
+        club: '',
+        time: `${team.totalScore} b.`,
+        change: 0
+      }))
+    }
+  } catch (err) {
+    console.error('Failed to fetch PS results:', err)
+  }
+})
+</script>
+
+<template>
+  <ResultsTable
+    v-if="results"
+    :data="results"
+  />
+</template>

--- a/app/types/api.d.ts
+++ b/app/types/api.d.ts
@@ -169,6 +169,12 @@ export interface ITimer {
   start_time: number // unix timestamp (seconds)
 }
 
+export interface IPsResultsTrigger {
+  eventId: number
+  group: string
+  final: boolean
+}
+
 export interface ClubFlagConfiguration {
   is_national: boolean
   is_relay: boolean

--- a/app/utils/gfx-state.ts
+++ b/app/utils/gfx-state.ts
@@ -3,6 +3,7 @@ import type {
   IFreeText,
   ILiveFeed,
   IParameters,
+  IPsResultsTrigger,
   IRaceTitle,
   IResults,
   ISingleRunner,
@@ -18,6 +19,7 @@ export interface GfxState {
   freetext: IFreeText | null
   liveFeed: ILiveFeed | null
   parameters: IParameters | null
+  psResults: IPsResultsTrigger | null
   results: IResults | null
   singleRunner: ISingleRunner | null
   speaker: ISpeaker | null
@@ -35,6 +37,7 @@ export function createDefaultState(): GfxState {
     freetext: null,
     liveFeed: null,
     parameters: null,
+    psResults: null,
     results: null,
     singleRunner: null,
     speaker: null,
@@ -61,6 +64,7 @@ export const eventMap: Record<string, keyof GfxState> = {
   'start': 'start',
   'start-group': 'startGroup',
   'results': 'results',
+  'ps-results': 'psResults',
   'flowers': 'flowers',
   'timer': 'timer'
 }
@@ -80,8 +84,9 @@ export const exclusions: Partial<Record<keyof GfxState, (keyof GfxState)[]>> = {
   freetext: ['liveFeed', 'singleRunner', 'start', 'startGroup', 'speaker', 'title', 'flowers'],
   title: ['liveFeed', 'singleRunner', 'start', 'startGroup', 'speaker', 'freetext', 'flowers', 'weather', 'parameters'],
   flowers: ['liveFeed', 'singleRunner', 'start', 'startGroup', 'speaker', 'freetext', 'title', 'parameters', 'weather'],
-  results: ['startlist'],
-  startlist: ['results'],
+  results: ['startlist', 'psResults'],
+  psResults: ['results', 'startlist'],
+  startlist: ['results', 'psResults'],
   weather: ['parameters', 'flowers', 'title'],
   parameters: ['weather', 'flowers', 'title']
 }


### PR DESCRIPTION
Add PS results overlay component for school championship standings. Receives trigger via SSE with eventId, group, and final flag. Fetches OResults data once, computes group standings, and renders via existing ResultsTable component. Mutually exclusive with results/startlist overlays.